### PR TITLE
fix issue 47: Hyperlinks in body copy are the same colour as body text

### DIFF
--- a/src/_sass/ztna-typography.scss
+++ b/src/_sass/ztna-typography.scss
@@ -79,7 +79,7 @@ a.text-link {
 }
 
 a {
-  color: inherit;
+  color: $light-blue-1;
   text-decoration: none;
 
   &:hover {


### PR DESCRIPTION
- change the color of unhovered links from inherit to #44a0f8


closes #47 