### PR TITLE
fix issue 43: Architecture illustrations rendered with poor quality

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -3730,6 +3730,7 @@ th {
   height: auto;
 }
 .item-detailed figure img:first-child {
+  image-rendering: -webkit-optimize-contrast;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   -webkit-transition: all 300ms ease-in-out 0.05s;


### PR DESCRIPTION
- add image-rendering property in style.css to improve image quality

closes #43 