### PR TITLE
fix issue 44: Selecting an architecture doesn't auto-scroll to the list of vendors 

### DIFF
--- a/src/_includes/landing/architecture-summary-section.html
+++ b/src/_includes/landing/architecture-summary-section.html
@@ -40,10 +40,6 @@
               <div class="ztna-button light-blue-background-1 white h4" onclick="location.hash=''; location.hash='#{{arch.filter}}';">
                 {{architecture-summary.button }}
               </div>
-              <!-- <a href="#filter={{arch.filter}}">
-                {%include components/link.html 
-                content=architecture-summary.button %}
-              </a> -->
             </div>
           </div>
 


### PR DESCRIPTION
- add an anchor link to scroll to the architecture

closes #44 