### PR TITLE
Minor corrections to Teleport entry in PAM list

### DIFF
--- a/src/_data/architecture/pam.yml
+++ b/src/_data/architecture/pam.yml
@@ -51,9 +51,9 @@ vendors:
 
   - company: "Gravitational, Inc"
     product: "Teleport"
-    url: "https://gravitational.com/teleport/"
+    url: "https://goteleport.com/"
     license: "Commercial"
-    deployment: "SaaS"
+    deployment: "SaaS or Self-hosted"
     pricing: "Published"
     notes: ""
 


### PR DESCRIPTION
Wrote a PR with a couple of minor changes:

- Update Teleport website URL to https://goteleport.com
- Clarify that Teleport has both SaaS and self-hosted options

Thanks!