### PR TITLE
Cosgrid vendor added to mesh-overlay.yml

### DIFF
--- a/src/_data/architecture/mesh-overlay.yml
+++ b/src/_data/architecture/mesh-overlay.yml
@@ -167,4 +167,14 @@ vendors:
     deployment: "SaaS"
     pricing: "Published"
     notes: ""
+
+  - company: "COSGrid Networks"
+    product: "MicroZAccess"
+    url: "https://www.cosgrid.com/"
+    license: "Commercial"
+    deployment: "SaaS"
+    pricing: "n/a"
+    notes: ""
+
+  
   


### PR DESCRIPTION
this is the new pull request based on the #77  .

#77 was closed before we gave our explanation. that' s why this new pull request is issued. 

@enclave-marc-barry

As per the classification definition listed on https://zerotrustnetworkaccess.info/, our COSGrid MicroZAccess(MZA) has the below key features:
"Agent based architecture. Devices talk directly to one another coordinated by centralised policy-based management. Direct connections between cooperating systems are established using outbound-only traffic and a combination of device and user identity, UDP & TCP hole punching and NAT traversal techniques together create fast, end-to-end encrypted tunnels between connected systems from behind closed firewalls"

MZA Depends on Trust Broker (in our case TURN Mediator)

Offers Mesh connectivity

Can handle East-West traffic

No gateway devices or proxy servers

However, Gateway or Appliance scenario, is where the MZA Software is installed on a linux Server or on a linux based SD-WAN gateway as an extension use case. Not the core use case. Again to clarify, we've extended the mesh overlay concept to Edge devices for service those use cases.

Again, we're very clear that COSGrid MZA belongs to Mesh Overlay Networks given that exhibits all the qualities of

We request you to consider the facts given above on COSGrid MZA architecture, not much on a diagram which could look like SDP to some. To clear the confusion, we have updated the architecture diagram.

Considering, that listing does not amount to certification by you, request you focus on the core character of the product and ignore any enhancements that may prompt you to make other category assumptions. We firmly believe that our architecture belongs to a Mesh Overlay Networks.

It's been more than a year since we raised the pull request, followed up multiple clarifications on this subject. I hope and look forward that you'll accept the pull request.

![351306470-b4523c57-9449-4951-bd56-7f993858868c](https://github.com/user-attachments/assets/558b1634-6251-42f2-b171-c90224f3be12)




