### PR TITLE
Update mesh-overlay.yml - Netbird is SaaS or Self-hosted

### DIFF
--- a/src/_data/architecture/mesh-overlay.yml
+++ b/src/_data/architecture/mesh-overlay.yml
@@ -100,7 +100,7 @@ vendors:
     product: "Netbird"
     url: "https://netbird.io/"
     license: "Open Source"
-    deployment: "SaaS"
+    deployment: "SaaS of Self-hosted"
     pricing: "Published"
     notes: "Formerly Wiretrustee"
 


### PR DESCRIPTION
Netbird is BSD-3 licensed and all functionality is available in self-hosted version: https://github.com/netbirdio/netbird